### PR TITLE
feature/dust_implement

### DIFF
--- a/Metallicity_Stack_Commons/__init__.py
+++ b/Metallicity_Stack_Commons/__init__.py
@@ -26,6 +26,8 @@ fitspath_reagen = '/Users/reagenleimbach/Desktop/Zcalbase_gal/'
 
 fitspath_caroline = 'C:/Users/carol/Google Drive/'
 
+fitspath_chun = '/Users/cly/GoogleDrive/Research/'
+
 scalefact = 1e-17
 
 # Flux ratio of [OIII]5007 to [OIII]4959
@@ -103,5 +105,8 @@ def get_user():
 
     if username == 'carol':
         fitspath = fitspath_caroline
+
+    if username == 'cly':
+        fitspath = fitspath_chun
 
     return fitspath

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -27,7 +27,7 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
     Purpose:
       Determines E(B-V) from Hg/Hb or Hd/Hb flux ratios using Case B assumptions
 
-    :param ratio: float or numpy array containing Hg/Hb or Hd/hb
+    :param ratio: float or numpy array containing Hg/Hb or Hd/Hb
     :param source: str indicate ratio type.  Either 'HgHb' or 'HdHb'. Default: 'HgHb'
     :param zero_neg: boolean to indicate whether to zero out negative reddening. Default: True
 

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -36,11 +36,11 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
         print("!!! Incorrect type for input [ratio].  Cannot be list !!!")
         raise TypeError
 
-    if source == 'HgHb':
+    if 'HgHb' in source:
         ratio0 = HgHb_CaseB
         k1 = k_HGAMMA
 
-    if source == 'HdHb':
+    if 'HdHb' in source:
         ratio0 = HdHb_CaseB
         k1 = k_HDELTA
 

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -33,6 +33,7 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
 
     :return EBV: float or numpy array containing E(B-V).
                  Note: Not correcting for negative reddening
+    :return EBV_peak: float or numpy array return when it is a 2-D distribution
     """
 
     if isinstance(ratio, list):
@@ -54,12 +55,14 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
             if EBV < 0.0:
                 EBV = 0.0
                 print('zero substituted for negative reddening')
+            return EBV
         else:
             if len(EBV.shape) == 1:
                 neg_idx = np.where(EBV < 0.0)[0]
                 if len(neg_idx) > 0:
                     EBV[neg_idx] = 0.0
                     print('zero substituted for negative reddening')
+                return EBV
             if len(EBV.shape) == 2:
                 EBV_avg = np.average(EBV, axis=0)  # initial guess
                 EBV_err, EBV_peak = compute_onesig_pdf(EBV, EBV_avg, usepeak=True)
@@ -68,7 +71,9 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
                     print('EBV distribution shifted for peak')
                     EBV[neg_idx, :] -= EBV_peak[neg_idx]
                     EBV_peak[neg_idx] = 0.0
-    return EBV, EBV_peak
+                return EBV, EBV_peak
+    else:
+        return EBV
 
 
 def EBV_table_update(fitspath, use_revised=False):

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -66,9 +66,9 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
                 neg_idx = np.where(EBV_peak < 0.0)[0]
                 if len(neg_idx) > 0:
                     print('EBV distribution shifted for peak')
-                    EBV[:, neg_idx] -= EBV_peak[neg_idx]
-
-    return EBV
+                    EBV[neg_idx, :] -= EBV_peak[neg_idx]
+                    EBV_peak[neg_idx] = 0.0
+    return EBV, EBV_peak
 
 
 def EBV_table_update(fitspath, use_revised=False):

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -72,56 +72,6 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
         return EBV
 
 
-# Code is deprecated. See error_prop.fluxes_derived_prop for table update with EBV
-'''
-def EBV_table_update(fitspath, use_revised=False):
-    """
-    Purpose:
-      Determines E(B-V) from Hg/Hb and Hd/Hb flux ratios by calling
-      compute_EBV() and update table
-
-    :param fitspath: str containing root path
-    :param use_revised: Boolean to indicate whether to use regular or revised tables
-    """
-
-    combine_file = join(fitspath, filename_dict['bin_fit_rev']) if use_revised \
-        else join(fitspath, filename_dict['bin_fit'])
-
-    print("Reading : " + combine_file)
-    combine_asc = asc.read(combine_file)
-
-    ID = combine_asc['bin_ID'].data
-    HBETA  = combine_asc[HB+'_Flux_Observed'].data
-    HGAMMA = combine_asc[HG+'_Flux_Observed'].data
-    HDELTA = combine_asc[HD+'_Flux_Observed'].data
-
-    HgHb = HGAMMA / HBETA
-    HdHb = HDELTA / HBETA
-
-    EBV_HgHb = compute_EBV(HgHb, source='HgHb')
-    EBV_HdHb = compute_EBV(HdHb, source='HdHb')
-
-    col1 = Column(HgHb,     name=dust0[0])
-    col2 = Column(HdHb,     name=dust0[1])
-    col3 = Column(EBV_HgHb, name=dust0[2])
-    col4 = Column(EBV_HdHb, name=dust0[3])
-
-    out_ascii = join(fitspath, filename_dict['bin_derived_prop_rev']) if use_revised \
-        else join(fitspath, filename_dict['bin_derived_prop'])
-
-    if not exists(out_ascii):
-        print("File not found : ", out_ascii)
-
-        raise FileNotFoundError
-    else:
-        tab1 = asc.read(out_ascii)
-        print("Adding dust attenuation information to " + out_ascii)
-
-        tab1.add_columns([col1, col2, col3, col4])
-        asc.write(tab1, out_ascii, format='fixed_width_two_line', overwrite=True)
-'''
-
-
 def compute_A(EBV):
     """
     Purpose:

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -76,6 +76,9 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
         return EBV
 
 
+# Code is deprecated. See error_prop.fluxes_derived_prop for table update with EBV
+# Note that EBV derived from Hd/Hb is not conducted in error_prop.fluxes_derived_prop
+'''
 def EBV_table_update(fitspath, use_revised=False):
     """
     Purpose:
@@ -121,6 +124,7 @@ def EBV_table_update(fitspath, use_revised=False):
 
         tab1.add_columns([col1, col2, col3, col4])
         asc.write(tab1, out_ascii, format='fixed_width_two_line', overwrite=True)
+'''
 
 
 def compute_A(EBV):

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -1,10 +1,6 @@
-from astropy.io import ascii as asc
-from astropy.table import Table, Column
 import numpy as np
-from os.path import join, exists
 
 from .. import k_dict, line_name_short
-from ..column_names import filename_dict, dust0
 
 from chun_codes import compute_onesig_pdf
 

--- a/Metallicity_Stack_Commons/analysis/attenuation.py
+++ b/Metallicity_Stack_Commons/analysis/attenuation.py
@@ -73,7 +73,6 @@ def compute_EBV(ratio, source='HgHb', zero_neg=True):
 
 
 # Code is deprecated. See error_prop.fluxes_derived_prop for table update with EBV
-# Note that EBV derived from Hd/Hb is not conducted in error_prop.fluxes_derived_prop
 '''
 def EBV_table_update(fitspath, use_revised=False):
     """

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -53,13 +53,17 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
     if binned_data:
         flux_file = join(path, filename_dict['bin_fit'])
         if not raw:
-            prop_file = join(path, filename_dict['bin_derived_prop'])
+            # Set rev_stuff based on revised=True/False
             if revised:
+                rev_s = ''
                 print('Using REVISED validation table')
                 verify_file = join(path, filename_dict['bin_valid_rev'])
             else:
+                rev_s = '_v1'
                 print('Using validation table')
                 verify_file = join(path, filename_dict['bin_valid'])
+
+            prop_file = join(path, filename_dict['bin_derived_prop' + rev_s])
 
         bin_ratios = bin_ratios0
         dust = dust0
@@ -146,9 +150,9 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
         tbl_dict.update(derived_prop_dict)
 
         if not apply_dust:
-            outfile = join(path, filename_dict['bin_derived_prop'])
+            outfile = join(path, filename_dict['bin_derived_prop' + rev_s])
         else:
-            outfile = join(path, filename_dict['bin_derived_prop_dust'])
+            outfile = join(path, filename_dict['bin_derived_prop_dust' + rev_s])
         if not exists(outfile):
             print("Writing : ", outfile)
         else:
@@ -177,7 +181,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
             flux_tab0[line_name[aa] + '_Flux_Gaussian'][detect_idx] = peak
 
         # Write revised emission-line fit ASCII table
-        new_flux_file = join(path, filename_dict['bin_fit_rev'])
+        new_flux_file = join(path, filename_dict['bin_fit_MC'])
         if exists(new_flux_file):
             print("Overwriting: "+new_flux_file)
         else:
@@ -302,9 +306,9 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
         # Write revised properties ASCII table
         if not apply_dust:
-            new_prop_file = join(path, filename_dict['bin_derived_prop_rev'])
+            new_prop_file = join(path, filename_dict['bin_derived_prop_MC' + rev_s])
         else:
-            new_prop_file = join(path, filename_dict['bin_derived_prop_rev_dust'])
+            new_prop_file = join(path, filename_dict['bin_derived_prop_MC_dust' + rev_s])
         if exists(new_prop_file):
             print("Overwriting: "+new_prop_file)
         else:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -106,7 +106,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
         print("Overwriting: "+new_flux_file)
     else:
         print("Writing: "+new_flux_file)
-    asc.write(flux_tab0, new_flux_file, overwrite=True, format='fixed_width_two_line')
+    asc.write(flux_tab0, new_flux_file, overwrite=True,
+              format='fixed_width_two_line')
 
     # Save flux npz files
     npz_files = [npz_filename_dict['flux_pdf'],
@@ -142,7 +143,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
 
     # Calculate metallicity distribution
     metal_dict = metallicity_calculation(Te_pdf, flux_ratios_dict['two_beta'],
-                                         flux_ratios_dict['three_beta'], EBV=EBV)
+                                         flux_ratios_dict['three_beta'],
+                                         EBV=EBV)
     derived_prop_pdf_dict.update(metal_dict)
 
     # Loop for each derived properties (T_e, metallicity, etc.)
@@ -150,7 +152,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
         arr0 = prop_tab[names0].data
 
         err_prop, peak_prop = \
-            compute_onesig_pdf(derived_prop_pdf_dict[names0], arr0, usepeak=True)
+            compute_onesig_pdf(derived_prop_pdf_dict[names0], arr0,
+                               usepeak=True)
 
         # Fill in dictionary
         derived_prop_error_dict[names0+'_error'] = err_prop
@@ -165,7 +168,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
         print("Overwriting: "+new_prop_file)
     else:
         print("Writing: "+new_prop_file)
-    asc.write(prop_tab0, new_prop_file, overwrite=True, format='fixed_width_two_line')
+    asc.write(prop_tab0, new_prop_file, overwrite=True,
+              format='fixed_width_two_line')
 
     # Save derived properties npz files
     npz_files = [npz_filename_dict['der_prop_pdf'],

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -101,7 +101,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
     if raw:
         flux_dict = dict()
-        for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
+        for aa, flux in zip(range(len(flux_cols)), flux_cols):
 
             # Fill in dictionary
             flux_dict[line_name[aa]] = flux_tab0[flux].data

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -190,9 +190,9 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
                   format='fixed_width_two_line')
 
         # Save flux npz files
-        npz_files = [npz_filename_dict['flux_pdf'],
-                     npz_filename_dict['flux_errors'],
-                     npz_filename_dict['flux_peak']]
+        npz_files = [npz_filename_dict['flux_pdf' + rev_s],
+                     npz_filename_dict['flux_errors' + rev_s],
+                     npz_filename_dict['flux_peak' + rev_s]]
         dict_list = [flux_pdf_dict, flux_error_dict, flux_peak_dict]
         write_npz(path, npz_files, dict_list)
 
@@ -318,13 +318,13 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
         # Save derived properties npz files
         if not apply_dust:
-            npz_files = [npz_filename_dict['der_prop_pdf'],
-                         npz_filename_dict['der_prop_errors'],
-                         npz_filename_dict['der_prop_peak']]
+            npz_files = [npz_filename_dict['der_prop_pdf' + rev_s],
+                         npz_filename_dict['der_prop_errors' + rev_s],
+                         npz_filename_dict['der_prop_peak' + rev_s]]
         else:
-            npz_files = [npz_filename_dict['der_prop_dust_pdf'],
-                         npz_filename_dict['der_prop_dust_errors'],
-                         npz_filename_dict['der_prop_dust_peak']]
+            npz_files = [npz_filename_dict['der_prop_dust_pdf' + rev_s],
+                         npz_filename_dict['der_prop_dust_errors' + rev_s],
+                         npz_filename_dict['der_prop_dust_peak' + rev_s]]
 
         dict_list = [derived_prop_pdf_dict, derived_prop_error_dict,
                      derived_prop_peak_dict]

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -164,7 +164,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
         # Randomization for emission-line fluxes
         for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
-            flux_pdf = random_pdf(flux_tab[flux], flux_tab[rms], seed_i=aa,
+            flux_pdf = random_pdf(flux_tab[flux], flux_tab[rms], seed_i=aa+1,
                                   n_iter=1000)
             err, peak = compute_onesig_pdf(flux_pdf, flux_tab[flux], usepeak=True)
 

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -221,9 +221,15 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
                   format='fixed_width_two_line')
 
         # Save derived properties npz files
-        npz_files = [npz_filename_dict['der_prop_pdf'],
-                     npz_filename_dict['der_prop_errors'],
-                     npz_filename_dict['der_prop_peak']]
+        if not apply_dust:
+            npz_files = [npz_filename_dict['der_prop_pdf'],
+                         npz_filename_dict['der_prop_errors'],
+                         npz_filename_dict['der_prop_peak']]
+        else:
+            npz_files = [npz_filename_dict['der_prop_dust_pdf'],
+                         npz_filename_dict['der_prop_dust_errors'],
+                         npz_filename_dict['der_prop_dust_peak']]
+
         dict_list = [derived_prop_pdf_dict, derived_prop_error_dict,
                      derived_prop_peak_dict]
         write_npz(path, npz_files, dict_list)

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -62,6 +62,8 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
                 verify_file = join(path, filename_dict['bin_valid'])
 
         bin_ratios = bin_ratios0
+        dust0[0] += '_composite'
+        dust0[1] += '_composite'
     else:
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
 

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -250,8 +250,13 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
                                              EBV=EBV)
         derived_prop_pdf_dict.update(metal_dict)
 
+        prop_err_dict = dict()  # Initialize
+
         # Loop for each derived properties (T_e, metallicity, etc.)
         for names0 in temp_metal_names0:
+            prop_err_dict[names0 + '_low_err'] = np.repeat(np.nan, len(prop_tab0))
+            prop_err_dict[names0 + '_high_err'] = np.repeat(np.nan, len(prop_tab0))
+
             arr0 = prop_tab[names0].data
 
             err_prop, peak_prop = \
@@ -262,8 +267,15 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
             derived_prop_error_dict[names0+'_error'] = err_prop
             derived_prop_peak_dict[names0+'_peak'] = peak_prop
 
+            prop_err_dict[names0 + '_low_err'][detect_idx] = err_prop[:, 0]
+            prop_err_dict[names0 + '_high_err'][detect_idx] = err_prop[:, 1]
+
             # Update values
             prop_tab0[names0][detect_idx] = peak_prop
+
+        # Add errors to table
+        prop_err_table = Table(prop_err_dict)
+        prop_tab0 = hstack([prop_tab0, prop_err_table])
 
         # Write revised properties ASCII table
         if not apply_dust:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -33,7 +33,8 @@ def write_npz(path, npz_files, dict_list):
         np.savez(npz_outfile, **dict_input)
 
 
-def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, revised=True):
+def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
+                        revised=True):
     """
     Purpose:
       Use measurements and their uncertainties to perform a randomization
@@ -87,6 +88,9 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
 
             flux_tab = flux_tab0[detect_idx]
             prop_tab = prop_tab0[detect_idx]
+    else:
+        print("Individual sources not supported yet")
+        return
 
     flux_cols     = [str0+'_Flux_Gaussian' for str0 in line_name]
     flux_rms_cols = [str0+'_RMS' for str0 in line_name]

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -5,7 +5,8 @@ from .. import line_name
 from astropy.io import ascii as asc
 import numpy as np
 
-from ..column_names import filename_dict, temp_metal_names0, npz_filename_dict
+from ..column_names import filename_dict, temp_metal_names0, npz_filename_dict, \
+    bin_names0
 from .ratios import flux_ratios
 from .temp_metallicity_calc import temp_calculation, metallicity_calculation
 from .attenuation import compute_EBV
@@ -31,7 +32,7 @@ def write_npz(path, npz_files, dict_list):
         np.savez(npz_outfile, **dict_input)
 
 
-def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
+def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, revised=True):
     """
     Purpose:
       Use measurements and their uncertainties to perform a randomization
@@ -40,6 +41,7 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
       determines electron temperature and metallicity
 
     :param path: str of full path
+    :param raw: bool to do a simple calculation, no randomization. Default: False
     :param binned_data: bool for whether to analysis binned data. Default: True
     :param apply_dust: bool for whether to apply dust attenuation. Default: False
     :param revised: bool to indicate if revised validation table is used. Default: True
@@ -48,31 +50,34 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
     # Define files to read in for binned data
     if binned_data:
         flux_file = join(path, filename_dict['bin_fit'])
-        prop_file = join(path, filename_dict['bin_derived_prop'])
-        if revised:
-            print('Using REVISED validation table')
-            verify_file = join(path, filename_dict['bin_valid_rev'])
-        else:
-            print('Using validation table')
-            verify_file = join(path, filename_dict['bin_valid'])
+        if not raw:
+            prop_file = join(path, filename_dict['bin_derived_prop'])
+            if revised:
+                print('Using REVISED validation table')
+                verify_file = join(path, filename_dict['bin_valid_rev'])
+            else:
+                print('Using validation table')
+                verify_file = join(path, filename_dict['bin_valid'])
 
     flux_tab0 = asc.read(flux_file)
-    prop_tab0 = asc.read(prop_file)
+    if not raw:
+        prop_tab0 = asc.read(prop_file)
 
     if binned_data:
-        verify_tab = asc.read(verify_file)
-        detection = verify_tab['Detection'].data
+        if not raw:
+            verify_tab = asc.read(verify_file)
+            detection = verify_tab['Detection'].data
 
-        # For now we are only considering those with reliable detection and
-        # excluding those with reliable non-detections (detect = 0.5)
-        detect_idx = np.where((detection == 1))[0]
+            # For now we are only considering those with reliable detection and
+            # excluding those with reliable non-detections (detect = 0.5)
+            detect_idx = np.where((detection == 1))[0]
 
-        ID = verify_tab['bin_ID'].data
-        ID_detect = ID[detect_idx]
-        print(ID_detect)
+            ID = verify_tab['bin_ID'].data
+            ID_detect = ID[detect_idx]
+            print(ID_detect)
 
-        flux_tab = flux_tab0[detect_idx]
-        prop_tab = prop_tab0[detect_idx]
+            flux_tab = flux_tab0[detect_idx]
+            prop_tab = prop_tab0[detect_idx]
 
     flux_cols     = [str0+'_Flux_Gaussian' for str0 in line_name]
     flux_rms_cols = [str0+'_RMS' for str0 in line_name]
@@ -81,104 +86,133 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
     # EMISSION-LINE SECTION
     #
 
-    # Initialize dictionaries
-    flux_pdf_dict = dict()
-    flux_peak_dict = dict()
-    flux_error_dict = dict()
+    if raw:
+        flux_dict = dict()
+        for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
 
-    # Randomization for emission-line fluxes
-    for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
-        flux_pdf = random_pdf(flux_tab[flux], flux_tab[rms], seed_i=aa,
-                              n_iter=1000)
-        err, peak = compute_onesig_pdf(flux_pdf, flux_tab[flux], usepeak=True)
+            # Fill in dictionary
+            flux_dict[line_name[aa]] = flux_tab0[flux].data
 
-        # Fill in dictionary
-        flux_pdf_dict[line_name[aa]] = flux_pdf
-        flux_peak_dict[line_name[aa] + '_peak'] = peak
-        flux_error_dict[line_name[aa] + '_error'] = err
+        flux_ratios_dict = flux_ratios(flux_dict)
 
-        # Update values
-        flux_tab0[line_name[aa] + '_Flux_Gaussian'][detect_idx] = peak
+        derived_prop_dict = dict()
 
-    # Write revised emission-line fit ASCII table
-    new_flux_file = join(path, filename_dict['bin_fit_rev'])
-    if exists(new_flux_file):
-        print("Overwriting: "+new_flux_file)
+        Te = temp_calculation(flux_ratios_dict['R'])
+        derived_prop_dict[temp_metal_names0[0]] = Te
+        metal_dict = metallicity_calculation(Te, flux_ratios_dict['two_beta'],
+                                             flux_ratios_dict['three_beta'])
+        derived_prop_dict.update(metal_dict)
+
+        # Write Astropy table
+        # Get bin IDs and composite measurements in one dicitonary and write to table
+        tbl_dict = {bin_names0[0]: np.int_(flux_tab0[bin_names0[0]].data)}
+        tbl_dict.update(flux_ratios_dict)
+        tbl_dict.update(derived_prop_dict)
+
+        outfile = join(path, filename_dict['bin_derived_prop'])
+        print("Writing : ", outfile)
+        asc.write(tbl_dict, output=outfile, overwrite=True,
+                  format='fixed_width_two_line')
     else:
-        print("Writing: "+new_flux_file)
-    asc.write(flux_tab0, new_flux_file, overwrite=True,
-              format='fixed_width_two_line')
+        # Initialize dictionaries
 
-    # Save flux npz files
-    npz_files = [npz_filename_dict['flux_pdf'],
-                 npz_filename_dict['flux_errors'],
-                 npz_filename_dict['flux_peak']]
-    dict_list = [flux_pdf_dict, flux_error_dict, flux_peak_dict]
-    write_npz(path, npz_files, dict_list)
+        flux_pdf_dict = dict()
+        flux_peak_dict = dict()
+        flux_error_dict = dict()
 
-    # Obtain line ratio distributions: logR23, logO32, two_beta, three_beta, R
-    # Also include Balmer decrements
-    flux_ratios_dict = flux_ratios(flux_pdf_dict)
+        # Randomization for emission-line fluxes
+        for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
+            flux_pdf = random_pdf(flux_tab[flux], flux_tab[rms], seed_i=aa,
+                                  n_iter=1000)
+            err, peak = compute_onesig_pdf(flux_pdf, flux_tab[flux], usepeak=True)
 
-    #
-    # Get EBV from Balmer decrement if apply_dust set
-    #
+            # Fill in dictionary
+            flux_pdf_dict[line_name[aa]] = flux_pdf
+            flux_peak_dict[line_name[aa] + '_peak'] = peak
+            flux_error_dict[line_name[aa] + '_error'] = err
 
-    if apply_dust:
-        EBV = compute_EBV(flux_ratios_dict['HgHb'], source='HgHb')
-    else:
-        EBV = None
+            # Update values
+            flux_tab0[line_name[aa] + '_Flux_Gaussian'][detect_idx] = peak
 
-    #
-    # DERIVED PROPERTIES SECTION
-    #
+        # Write revised emission-line fit ASCII table
+        new_flux_file = join(path, filename_dict['bin_fit_rev'])
+        if exists(new_flux_file):
+            print("Overwriting: "+new_flux_file)
+        else:
+            print("Writing: "+new_flux_file)
+        asc.write(flux_tab0, new_flux_file, overwrite=True,
+                  format='fixed_width_two_line')
 
-    # Initialize dictionaries
-    derived_prop_pdf_dict = dict()
-    derived_prop_error_dict = dict()
-    derived_prop_peak_dict = dict()
+        # Save flux npz files
+        npz_files = [npz_filename_dict['flux_pdf'],
+                     npz_filename_dict['flux_errors'],
+                     npz_filename_dict['flux_peak']]
+        dict_list = [flux_pdf_dict, flux_error_dict, flux_peak_dict]
+        write_npz(path, npz_files, dict_list)
 
-    # Calculate temperature distribution
-    Te_pdf = temp_calculation(flux_ratios_dict['R'], EBV=EBV)
-    derived_prop_pdf_dict[temp_metal_names0[0]] = Te_pdf
+        # Obtain line ratio distributions: logR23, logO32, two_beta, three_beta, R
+        # Also include Balmer decrements
+        flux_ratios_dict = flux_ratios(flux_pdf_dict)
 
-    # Calculate metallicity distribution
-    metal_dict = metallicity_calculation(Te_pdf, flux_ratios_dict['two_beta'],
-                                         flux_ratios_dict['three_beta'],
-                                         EBV=EBV)
-    derived_prop_pdf_dict.update(metal_dict)
+        #
+        # Get EBV from Balmer decrement if apply_dust set
+        #
 
-    # Loop for each derived properties (T_e, metallicity, etc.)
-    for names0 in temp_metal_names0:
-        arr0 = prop_tab[names0].data
+        if apply_dust:
+            EBV = compute_EBV(flux_ratios_dict['HgHb'], source='HgHb')
+        else:
+            EBV = None
 
-        err_prop, peak_prop = \
-            compute_onesig_pdf(derived_prop_pdf_dict[names0], arr0,
-                               usepeak=True)
+        #
+        # DERIVED PROPERTIES SECTION
+        #
 
-        # Fill in dictionary
-        derived_prop_error_dict[names0+'_error'] = err_prop
-        derived_prop_peak_dict[names0+'_peak'] = peak_prop
+        # Initialize dictionaries
+        derived_prop_pdf_dict = dict()
+        derived_prop_error_dict = dict()
+        derived_prop_peak_dict = dict()
 
-        # Update values
-        prop_tab0[names0][detect_idx] = peak_prop
+        # Calculate temperature distribution
+        Te_pdf = temp_calculation(flux_ratios_dict['R'], EBV=EBV)
+        derived_prop_pdf_dict[temp_metal_names0[0]] = Te_pdf
 
-    # Write revised properties ASCII table
-    if not apply_dust:
-        new_prop_file = join(path, filename_dict['bin_derived_prop_rev'])
-    else:
-        new_prop_file = join(path, filename_dict['bin_derived_prop_rev_dust'])
-    if exists(new_prop_file):
-        print("Overwriting: "+new_prop_file)
-    else:
-        print("Writing: "+new_prop_file)
-    asc.write(prop_tab0, new_prop_file, overwrite=True,
-              format='fixed_width_two_line')
+        # Calculate metallicity distribution
+        metal_dict = metallicity_calculation(Te_pdf, flux_ratios_dict['two_beta'],
+                                             flux_ratios_dict['three_beta'],
+                                             EBV=EBV)
+        derived_prop_pdf_dict.update(metal_dict)
 
-    # Save derived properties npz files
-    npz_files = [npz_filename_dict['der_prop_pdf'],
-                 npz_filename_dict['der_prop_errors'],
-                 npz_filename_dict['der_prop_peak']]
-    dict_list = [derived_prop_pdf_dict, derived_prop_error_dict,
-                 derived_prop_peak_dict]
-    write_npz(path, npz_files, dict_list)
+        # Loop for each derived properties (T_e, metallicity, etc.)
+        for names0 in temp_metal_names0:
+            arr0 = prop_tab[names0].data
+
+            err_prop, peak_prop = \
+                compute_onesig_pdf(derived_prop_pdf_dict[names0], arr0,
+                                   usepeak=True)
+
+            # Fill in dictionary
+            derived_prop_error_dict[names0+'_error'] = err_prop
+            derived_prop_peak_dict[names0+'_peak'] = peak_prop
+
+            # Update values
+            prop_tab0[names0][detect_idx] = peak_prop
+
+        # Write revised properties ASCII table
+        if not apply_dust:
+            new_prop_file = join(path, filename_dict['bin_derived_prop_rev'])
+        else:
+            new_prop_file = join(path, filename_dict['bin_derived_prop_rev_dust'])
+        if exists(new_prop_file):
+            print("Overwriting: "+new_prop_file)
+        else:
+            print("Writing: "+new_prop_file)
+        asc.write(prop_tab0, new_prop_file, overwrite=True,
+                  format='fixed_width_two_line')
+
+        # Save derived properties npz files
+        npz_files = [npz_filename_dict['der_prop_pdf'],
+                     npz_filename_dict['der_prop_errors'],
+                     npz_filename_dict['der_prop_peak']]
+        dict_list = [derived_prop_pdf_dict, derived_prop_error_dict,
+                     derived_prop_peak_dict]
+        write_npz(path, npz_files, dict_list)

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -116,7 +116,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
     dict_list = [flux_pdf_dict, flux_error_dict, flux_peak_dict]
     write_npz(path, npz_files, dict_list)
 
-    # Obtain distributions of line ratios: logR23, logO32, two_beta, three_beta, R
+    # Obtain line ratio distributions: logR23, logO32, two_beta, three_beta, R
+    # Also include Balmer decrements
     flux_ratios_dict = flux_ratios(flux_pdf_dict)
 
     #
@@ -163,7 +164,10 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
         prop_tab0[names0][detect_idx] = peak_prop
 
     # Write revised properties ASCII table
-    new_prop_file = join(path, filename_dict['bin_derived_prop_rev'])
+    if not apply_dust:
+        new_prop_file = join(path, filename_dict['bin_derived_prop_rev'])
+    else:
+        new_prop_file = join(path, filename_dict['bin_derived_prop_rev_dust'])
     if exists(new_prop_file):
         print("Overwriting: "+new_prop_file)
     else:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -52,24 +52,29 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
     # Define files to read in for binned data
     if binned_data:
         flux_file = join(path, filename_dict['bin_fit'])
-        if not raw:
-            # Set rev_stuff based on revised=True/False
-            if revised:
-                rev_s = ''
-                print('Using REVISED validation table')
-                verify_file = join(path, filename_dict['bin_valid_rev'])
-            else:
-                rev_s = '_v1'
-                print('Using validation table')
-                verify_file = join(path, filename_dict['bin_valid'])
 
-            prop_file = join(path, filename_dict['bin_derived_prop' + rev_s])
-
-        bin_ratios = bin_ratios0
-        dust = dust0
-    else:
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
         dust = [t_dust.replace('_composite', '') for t_dust in dust0]
+    else:
+        bin_ratios = bin_ratios0
+        dust = dust0
+
+    # Define verification table
+    if revised:
+        rev_s = ''
+        print('Using REVISED validation table')
+        verify_file = join(path, filename_dict['bin_valid_rev'])
+    else:
+        rev_s = '_v1'
+        print('Using validation table')
+        verify_file = join(path, filename_dict['bin_valid'])
+
+    if not raw:
+        # Set rev_stuff based on revised=True/False
+        prop_file = join(path, filename_dict['bin_derived_prop' + rev_s])
+
+        print("Reading : "+prop_file)
+        prop_tab0 = asc.read(prop_file)
 
     two_beta_name = bin_ratios[2]
     three_beta_name = bin_ratios[3]
@@ -77,10 +82,6 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
     print("Reading : " + flux_file)
     flux_tab0 = asc.read(flux_file)
-
-    if not raw:
-        print("Reading : "+prop_file)
-        prop_tab0 = asc.read(prop_file)
 
     if binned_data:
         if not raw:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -157,6 +157,14 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
         # Also include Balmer decrements
         flux_ratios_dict = flux_ratios(flux_pdf_dict)
 
+        for name0 in flux_ratios_dict.keys():
+            err_prop, peak_prop = compute_onesig_pdf(flux_ratios_dict[name0],
+                                                     prop_tab0[name0],
+                                                     usepeak=True)
+
+            # Update values
+            prop_tab0[name0][detect_idx] = peak_prop
+
         #
         # Get EBV from Balmer decrement if apply_dust set
         #

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -62,10 +62,10 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
                 verify_file = join(path, filename_dict['bin_valid'])
 
         bin_ratios = bin_ratios0
-        dust0[0] += '_composite'
-        dust0[1] += '_composite'
+        dust = dust0
     else:
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
+        dust = [t_dust.replace('_composite', '') for t_dust in dust0]
 
     two_beta_name = bin_ratios[2]
     three_beta_name = bin_ratios[3]
@@ -119,8 +119,8 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
         #
 
         if apply_dust:
-            EBV = compute_EBV(flux_ratios_dict[dust0[0]], source=dust0[0])
-            EBV_HdHb = compute_EBV(flux_ratios_dict[dust0[1]], source=dust0[0])
+            EBV = compute_EBV(flux_ratios_dict[dust[0]], source=dust[0])
+            EBV_HdHb = compute_EBV(flux_ratios_dict[dust[1]], source=dust[0])
         else:
             EBV = None
             EBV_HdHb = None
@@ -136,8 +136,8 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
         derived_prop_dict.update(metal_dict)
 
         if apply_dust:
-            derived_prop_dict[dust0[2]] = EBV
-            derived_prop_dict[dust0[3]] = EBV_HdHb
+            derived_prop_dict[dust[2]] = EBV
+            derived_prop_dict[dust[3]] = EBV_HdHb
 
         # Write Astropy table
         # Get bin IDs and composite measurements in one dictionary and write to table
@@ -221,32 +221,35 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
         if apply_dust:
             # Hg/Hb case
-            EBV_dict = {dust0[2]: np.repeat(np.nan, len(prop_tab0)),
-                        dust0[2] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
-                        dust0[2] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
+            EBV_dict = {dust[2]: np.repeat(np.nan, len(prop_tab0)),
+                        dust[2] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
+                        dust[2] + '_high_err': np.repeat(np.nan, len(prop_tab0)),
+                        dust[3]: np.repeat(np.nan, len(prop_tab0)),
+                        dust[3] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
+                        dust[3] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
 
-            EBV, EBV_peak = compute_EBV(flux_ratios_dict[dust0[0]], source=dust0[0])
+            EBV, EBV_peak = compute_EBV(flux_ratios_dict[dust[0]], source=dust[0])
 
             err_prop, peak_prop = compute_onesig_pdf(EBV, EBV_peak, usepeak=True)
 
-            EBV_dict[dust0[2]][detect_idx] = peak_prop
-            EBV_dict[dust0[2] + '_low_err'][detect_idx] = err_prop[:, 0]
-            EBV_dict[dust0[2] + '_high_err'][detect_idx] = err_prop[:, 1]
+            EBV_dict[dust[2]][detect_idx] = peak_prop
+            EBV_dict[dust[2] + '_low_err'][detect_idx] = err_prop[:, 0]
+            EBV_dict[dust[2] + '_high_err'][detect_idx] = err_prop[:, 1]
             EBV_table = Table(EBV_dict)
             prop_tab0 = hstack([prop_tab0, EBV_table])
 
             # Hd/Hb case
-            EBV_HdHb_dict = {dust0[3]: np.repeat(np.nan, len(prop_tab0)),
-                             dust0[3] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
-                             dust0[3] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
+            EBV_HdHb_dict = {dust[3]: np.repeat(np.nan, len(prop_tab0)),
+                             dust[3] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
+                             dust[3] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
 
-            EBV_HdHb, EBV_HdHb_peak = compute_EBV(flux_ratios_dict[dust0[1]], source=dust0[1])
+            EBV_HdHb, EBV_HdHb_peak = compute_EBV(flux_ratios_dict[dust[1]], source=dust[1])
 
             err_prop, peak_prop = compute_onesig_pdf(EBV_HdHb, EBV_HdHb_peak, usepeak=True)
 
-            EBV_dict[dust0[3]][detect_idx] = peak_prop
-            EBV_dict[dust0[3] + '_low_err'][detect_idx] = err_prop[:, 0]
-            EBV_dict[dust0[3] + '_high_err'][detect_idx] = err_prop[:, 1]
+            EBV_dict[dust[3]][detect_idx] = peak_prop
+            EBV_dict[dust[3] + '_low_err'][detect_idx] = err_prop[:, 0]
+            EBV_dict[dust[3] + '_high_err'][detect_idx] = err_prop[:, 1]
 
             # Add EBV and errors to table
             EBV_table = Table(EBV_HdHb_dict)

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -69,12 +69,16 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
     three_beta_name = bin_ratios[3]
     R_name = bin_ratios[4]
 
+    print("Reading : " + flux_file)
     flux_tab0 = asc.read(flux_file)
+
     if not raw:
+        print("Reading : "+prop_file)
         prop_tab0 = asc.read(prop_file)
 
     if binned_data:
         if not raw:
+            print("Reading : "+verify_file)
             verify_tab = asc.read(verify_file)
             detection = verify_tab['Detection'].data
 

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -52,12 +52,11 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
     # Define files to read in for binned data
     if binned_data:
         flux_file = join(path, filename_dict['bin_fit'])
-
-        bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
-        dust = [t_dust.replace('_composite', '') for t_dust in dust0]
-    else:
         bin_ratios = bin_ratios0
         dust = dust0
+    else:
+        bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
+        dust = [t_dust.replace('_composite', '') for t_dust in dust0]
 
     # Define verification table
     if revised:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -83,8 +83,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
 
     # Initialize dictionaries
     flux_pdf_dict = dict()
-    flux_peak = dict()
-    flux_lowhigh = dict()
+    flux_peak_dict = dict()
+    flux_error_dict = dict()
 
     # Randomization for emission-line fluxes
     for aa, flux, rms in zip(range(len(flux_cols)), flux_cols, flux_rms_cols):
@@ -94,8 +94,8 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
 
         # Fill in dictionary
         flux_pdf_dict[line_name[aa]] = flux_pdf
-        flux_peak[line_name[aa] + '_peak'] = peak
-        flux_lowhigh[line_name[aa] + '_lowhigh_error'] = err
+        flux_peak_dict[line_name[aa] + '_peak'] = peak
+        flux_error_dict[line_name[aa] + '_error'] = err
 
         # Update values
         flux_tab0[line_name[aa] + '_Flux_Gaussian'][detect_idx] = peak
@@ -112,7 +112,7 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
     npz_files = [npz_filename_dict['flux_pdf'],
                  npz_filename_dict['flux_errors'],
                  npz_filename_dict['flux_peak']]
-    dict_list = [flux_pdf_dict, flux_lowhigh, flux_peak]
+    dict_list = [flux_pdf_dict, flux_error_dict, flux_peak_dict]
     write_npz(path, npz_files, dict_list)
 
     # Obtain distributions of line ratios: logR23, logO32, two_beta, three_beta, R
@@ -153,7 +153,7 @@ def fluxes_derived_prop(path, binned_data=True, apply_dust=False, revised=True):
             compute_onesig_pdf(derived_prop_pdf_dict[names0], arr0, usepeak=True)
 
         # Fill in dictionary
-        derived_prop_error_dict[names0+'_lowhigh_error'] = err_prop
+        derived_prop_error_dict[names0+'_error'] = err_prop
         derived_prop_peak_dict[names0+'_peak'] = peak_prop
 
         # Update values

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -110,7 +110,10 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
         tbl_dict.update(derived_prop_dict)
 
         outfile = join(path, filename_dict['bin_derived_prop'])
-        print("Writing : ", outfile)
+        if not exists(outfile):
+            print("Writing : ", outfile)
+        else:
+            print("Overwriting : ", outfile)
         asc.write(tbl_dict, output=outfile, overwrite=True,
                   format='fixed_width_two_line')
     else:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -223,10 +223,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
             # Hg/Hb case
             EBV_dict = {dust[2]: np.repeat(np.nan, len(prop_tab0)),
                         dust[2] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
-                        dust[2] + '_high_err': np.repeat(np.nan, len(prop_tab0)),
-                        dust[3]: np.repeat(np.nan, len(prop_tab0)),
-                        dust[3] + '_low_err': np.repeat(np.nan, len(prop_tab0)),
-                        dust[3] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
+                        dust[2] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
 
             EBV, EBV_peak = compute_EBV(flux_ratios_dict[dust[0]], source=dust[0])
 
@@ -247,9 +244,9 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
             err_prop, peak_prop = compute_onesig_pdf(EBV_HdHb, EBV_HdHb_peak, usepeak=True)
 
-            EBV_dict[dust[3]][detect_idx] = peak_prop
-            EBV_dict[dust[3] + '_low_err'][detect_idx] = err_prop[:, 0]
-            EBV_dict[dust[3] + '_high_err'][detect_idx] = err_prop[:, 1]
+            EBV_HdHb_dict[dust[3]][detect_idx] = peak_prop
+            EBV_HdHb_dict[dust[3] + '_low_err'][detect_idx] = err_prop[:, 0]
+            EBV_HdHb_dict[dust[3] + '_high_err'][detect_idx] = err_prop[:, 1]
 
             # Add EBV and errors to table
             EBV_table = Table(EBV_HdHb_dict)

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -186,6 +186,8 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
         # Also include Balmer decrements
         flux_ratios_dict = flux_ratios(flux_pdf_dict, binned_data=binned_data)
 
+        flux_ratios_err_dict = dict()
+
         for name0 in flux_ratios_dict.keys():
             err_prop, peak_prop = compute_onesig_pdf(flux_ratios_dict[name0],
                                                      prop_tab0[name0],
@@ -193,6 +195,15 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
 
             # Update values
             prop_tab0[name0][detect_idx] = peak_prop
+
+            flux_ratios_err_dict[name0 + '_low_err'] = np.repeat(np.nan, len(prop_tab0))
+            flux_ratios_err_dict[name0 + '_high_err'] = np.repeat(np.nan, len(prop_tab0))
+            flux_ratios_err_dict[name0 + '_low_err'][detect_idx] = err_prop[:, 0]
+            flux_ratios_err_dict[name0 + '_high_err'][detect_idx] = err_prop[:, 1]
+
+        # Add flux ratio errors to table
+        prop_err_table = Table(flux_ratios_err_dict)
+        prop_tab0 = hstack([prop_tab0, prop_err_table])
 
         #
         # Get EBV from Balmer decrement if apply_dust set
@@ -226,6 +237,8 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False, rev
             EBV_dict[dust0[3]][detect_idx] = peak_prop
             EBV_dict[dust0[3] + '_low_err'][detect_idx] = err_prop[:, 0]
             EBV_dict[dust0[3] + '_high_err'][detect_idx] = err_prop[:, 1]
+
+            # Add EBV and errors to table
             EBV_table = Table(EBV_HdHb_dict)
             prop_tab0 = hstack([prop_tab0, EBV_table])
         else:

--- a/Metallicity_Stack_Commons/analysis/error_prop.py
+++ b/Metallicity_Stack_Commons/analysis/error_prop.py
@@ -124,7 +124,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
 
         if apply_dust:
             EBV = compute_EBV(flux_ratios_dict[dust[0]], source=dust[0])
-            EBV_HdHb = compute_EBV(flux_ratios_dict[dust[1]], source=dust[0])
+            EBV_HdHb = compute_EBV(flux_ratios_dict[dust[1]], source=dust[1])
         else:
             EBV = None
             EBV_HdHb = None
@@ -230,6 +230,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
                         dust[2] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
 
             EBV, EBV_peak = compute_EBV(flux_ratios_dict[dust[0]], source=dust[0])
+            print(EBV_peak)
 
             err_prop, peak_prop = compute_onesig_pdf(EBV, EBV_peak, usepeak=True)
 
@@ -245,6 +246,7 @@ def fluxes_derived_prop(path, raw=False, binned_data=True, apply_dust=False,
                              dust[3] + '_high_err': np.repeat(np.nan, len(prop_tab0))}
 
             EBV_HdHb, EBV_HdHb_peak = compute_EBV(flux_ratios_dict[dust[1]], source=dust[1])
+            print(EBV_HdHb_peak)
 
             err_prop, peak_prop = compute_onesig_pdf(EBV_HdHb, EBV_HdHb_peak, usepeak=True)
 

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .. import line_name_short, OIII_r
 from .temp_metallicity_calc import R_calculation
-from ..column_names import bin_ratios0
+from ..column_names import bin_ratios0, dust0
 
 
 def flux_ratios(flux_dict, binned_data=False, get_R=True):
@@ -49,12 +49,12 @@ def flux_ratios(flux_dict, binned_data=False, get_R=True):
 
     # Add Balmer decrement
     if line_name_short['HG'] in flux_dict:
-        flux_ratios_dict['HgHb'] = flux_dict[line_name_short['HG']] / Hb
+        flux_ratios_dict[dust0[0]] = flux_dict[line_name_short['HG']] / Hb
     if line_name_short['HD'] in flux_dict:
-        flux_ratios_dict['HdHb'] = flux_dict[line_name_short['HD']] / Hb
+        flux_ratios_dict[dust0[1]] = flux_dict[line_name_short['HD']] / Hb
 
     if get_R:
-        OIII4363 = flux_dict[line_name_short['4363']] # Retrieve OIII4363
+        OIII4363 = flux_dict[line_name_short['4363']]  # Retrieve OIII4363
         flux_ratios_dict[R_key] = R_calculation(OIII4363, OIII)
 
     return flux_ratios_dict

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -43,11 +43,7 @@ def flux_ratios(flux_dict, EBV=None, get_R=True):
     if line_name_short['HD'] in flux_dict:
         flux_ratios_dict['HdHb'] = flux_dict[line_name_short['HD']] / Hb
 
-    if EBV is None:
-        print("Not applying dust attenuation correction")
-        EBV = np.zeros(OIII.shape)
-
     if get_R:
-        flux_ratios_dict['R'] = R_calculation(OIII4363, OIII, EBV)
+        flux_ratios_dict['R'] = R_calculation(OIII4363, OIII, EBV=EBV)
 
     return flux_ratios_dict

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -21,6 +21,8 @@ def flux_ratios(flux_dict, binned_data=False, get_R=True):
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
     else:
         bin_ratios = bin_ratios0
+        dust0[0] += '_composite'
+        dust0[1] += '_composite'
 
     two_beta_key = bin_ratios[2]
     three_beta_key = bin_ratios[3]

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -2,9 +2,10 @@ import numpy as np
 
 from .. import line_name_short, OIII_r
 from .temp_metallicity_calc import R_calculation
+from ..column_names import bin_ratios0
 
 
-def flux_ratios(flux_dict, get_R=True):
+def flux_ratios(flux_dict, binned_data=False, get_R=True):
     """
     Purpose:
       Primary code to determine a variety of line ratios based on a dictionary
@@ -12,7 +13,7 @@ def flux_ratios(flux_dict, get_R=True):
 
     :param flux_dict: dictionary containing line ratios
     :param get_R: Boolean to indicate whether to get OIII4363/OIII5007 flux ratio for temp calculation
-
+    :param binned_data: bool for whether to analysis binned data. Default: False
     :return flux_ratios_dict: dictionary containing flux ratios
     """
 
@@ -31,10 +32,16 @@ def flux_ratios(flux_dict, get_R=True):
 
     # Define dictionary of flux ratios
     flux_ratios_dict = dict()
-    flux_ratios_dict['two_beta'] = two_beta
-    flux_ratios_dict['three_beta'] = three_beta
-    flux_ratios_dict['logR23'] = logR23
-    flux_ratios_dict['logO32'] = logO32
+
+    if not binned_data:
+        bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
+    else:
+        bin_ratios = bin_ratios0
+
+    flux_ratios_dict[bin_ratios[2]] = two_beta
+    flux_ratios_dict[bin_ratios[3]] = three_beta
+    flux_ratios_dict[bin_ratios[0]] = logR23
+    flux_ratios_dict[bin_ratios[1]] = logO32
 
     # Add Balmer decrement
     if line_name_short['HG'] in flux_dict:
@@ -43,6 +50,6 @@ def flux_ratios(flux_dict, get_R=True):
         flux_ratios_dict['HdHb'] = flux_dict[line_name_short['HD']] / Hb
 
     if get_R:
-        flux_ratios_dict['R'] = R_calculation(OIII4363, OIII)
+        flux_ratios_dict[bin_ratios[4]] = R_calculation(OIII4363, OIII)
 
     return flux_ratios_dict

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -21,8 +21,6 @@ def flux_ratios(flux_dict, binned_data=False, get_R=True):
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
     else:
         bin_ratios = bin_ratios0
-        dust0[0] += '_composite'
-        dust0[1] += '_composite'
 
     two_beta_key = bin_ratios[2]
     three_beta_key = bin_ratios[3]

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -4,14 +4,13 @@ from .. import line_name_short, OIII_r
 from .temp_metallicity_calc import R_calculation
 
 
-def flux_ratios(flux_dict, EBV=None, get_R=True):
+def flux_ratios(flux_dict, get_R=True):
     """
     Purpose:
       Primary code to determine a variety of line ratios based on a dictionary
       containing emission-line fluxes
 
     :param flux_dict: dictionary containing line ratios
-    :param EBV: array of E(B-V). Same dimensions as contents of flux_dict
     :param get_R: Boolean to indicate whether to get OIII4363/OIII5007 flux ratio for temp calculation
 
     :return flux_ratios_dict: dictionary containing flux ratios
@@ -44,6 +43,6 @@ def flux_ratios(flux_dict, EBV=None, get_R=True):
         flux_ratios_dict['HdHb'] = flux_dict[line_name_short['HD']] / Hb
 
     if get_R:
-        flux_ratios_dict['R'] = R_calculation(OIII4363, OIII, EBV=EBV)
+        flux_ratios_dict['R'] = R_calculation(OIII4363, OIII)
 
     return flux_ratios_dict

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -19,8 +19,10 @@ def flux_ratios(flux_dict, binned_data=False, get_R=True):
 
     if not binned_data:
         bin_ratios = [ratios0.replace('_composite', '') for ratios0 in bin_ratios0]
+        dust = [t_dust.replace('_composite', '') for t_dust in dust0]
     else:
         bin_ratios = bin_ratios0
+        dust = dust0
 
     two_beta_key = bin_ratios[2]
     three_beta_key = bin_ratios[3]
@@ -49,9 +51,9 @@ def flux_ratios(flux_dict, binned_data=False, get_R=True):
 
     # Add Balmer decrement
     if line_name_short['HG'] in flux_dict:
-        flux_ratios_dict[dust0[0]] = flux_dict[line_name_short['HG']] / Hb
+        flux_ratios_dict[dust[0]] = flux_dict[line_name_short['HG']] / Hb
     if line_name_short['HD'] in flux_dict:
-        flux_ratios_dict[dust0[1]] = flux_dict[line_name_short['HD']] / Hb
+        flux_ratios_dict[dust[1]] = flux_dict[line_name_short['HD']] / Hb
 
     if get_R:
         OIII4363 = flux_dict[line_name_short['4363']]  # Retrieve OIII4363

--- a/Metallicity_Stack_Commons/analysis/ratios.py
+++ b/Metallicity_Stack_Commons/analysis/ratios.py
@@ -37,6 +37,12 @@ def flux_ratios(flux_dict, EBV=None, get_R=True):
     flux_ratios_dict['logR23'] = logR23
     flux_ratios_dict['logO32'] = logO32
 
+    # Add Balmer decrement
+    if line_name_short['HG'] in flux_dict:
+        flux_ratios_dict['HgHb'] = flux_dict[line_name_short['HG']] / Hb
+    if line_name_short['HD'] in flux_dict:
+        flux_ratios_dict['HdHb'] = flux_dict[line_name_short['HD']] / Hb
+
     if EBV is None:
         print("Not applying dust attenuation correction")
         EBV = np.zeros(OIII.shape)

--- a/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
+++ b/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
@@ -4,6 +4,8 @@ from .. import k_dict, OIII_r
 
 from ..column_names import temp_metal_names0, remove_from_list
 
+k_3727 = k_dict['OII_3727']
+k_4861 = k_dict['HBETA']
 k_4363 = k_dict['OIII_4363']
 k_5007 = k_dict['OIII_5007']
 
@@ -48,7 +50,7 @@ def temp_calculation(R):
     return T_e
 
 
-def metallicity_calculation(T_e, TWO_BETA, THREE_BETA, det3=None):
+def metallicity_calculation(T_e, TWO_BETA, THREE_BETA, EBV=None, det3=None):
     """
     Determines 12+log(O/H) from electron temperature and [OII]/Hb and [OIII]/Hb flux ratio
 
@@ -67,6 +69,10 @@ def metallicity_calculation(T_e, TWO_BETA, THREE_BETA, det3=None):
     t_2 = np.zeros(arr_shape)
     x2 = np.zeros(arr_shape)
 
+    if EBV is None:
+        print("Not applying dust attenuation correction")
+        EBV = np.zeros(arr_shape)
+
     if det3 is None:
         det3 = np.arange(arr_shape[0])
 
@@ -83,6 +89,10 @@ def metallicity_calculation(T_e, TWO_BETA, THREE_BETA, det3=None):
                         np.log10(1 + 1.35 * x2[det3]) - 12
     O_d_ion_log[det3] = np.log10(THREE_BETA[det3]) + 6.200 + 1.251 / t_3[det3] \
                         - 0.55 * np.log10(t_3[det3]) - 0.014 * (t_3[det3]) - 12
+
+    # Apply dust attenuation to derived properties
+    O_s_ion_log[det3] += 0.4 * EBV[det3] * (k_3727 - k_4861)
+    O_d_ion_log[det3] += 0.4 * EBV[det3] * (k_5007 - k_4861)
 
     O_s_ion = 10 ** O_s_ion_log
     O_d_ion = 10 ** O_d_ion_log

--- a/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
+++ b/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
@@ -15,7 +15,7 @@ b = 0.92506
 c = 0.98062
 
 
-def R_calculation(OIII4363, OIII5007, EBV):
+def R_calculation(OIII4363, OIII5007, EBV=None):
     """
     Computes the excitation flux ratio of [OIII]4363 to [OIII]5007.
     Adopts a 3.1-to-1 ratio for 5007/4959
@@ -26,6 +26,10 @@ def R_calculation(OIII4363, OIII5007, EBV):
 
     :return R_value: O++ excitation flux ratio
     """
+
+    if EBV is None:
+        print("Not applying dust attenuation correction")
+        EBV = np.zeros(OIII4363.shape)
 
     R_value = OIII4363 / (OIII5007 * (1 + 1/OIII_r)) * 10 ** (0.4 * EBV * (k_4363 - k_5007))
 

--- a/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
+++ b/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .. import k_dict
+from .. import k_dict, OIII_r
 
 from ..column_names import temp_metal_names0, remove_from_list
 
@@ -25,7 +25,7 @@ def R_calculation(OIII4363, OIII5007, EBV):
     :return R_value: O++ excitation flux ratio
     """
 
-    R_value = OIII4363 / (OIII5007 * (1 + 1 / 3.1)) * 10 ** (0.4 * EBV * (k_4363 - k_5007))
+    R_value = OIII4363 / (OIII5007 * (1 + 1/OIII_r)) * 10 ** (0.4 * EBV * (k_4363 - k_5007))
 
     return R_value
 

--- a/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
+++ b/Metallicity_Stack_Commons/analysis/temp_metallicity_calc.py
@@ -44,9 +44,11 @@ def temp_calculation(R, EBV=None):
     :return T_e: numpy array of T_e (Kelvins)
     """
 
+    arr_shape = R.shape
+
     if EBV is None:
         print("temp_calculation - Not applying dust attenuation correction")
-        EBV = np.zeros(OIII4363.shape)
+        EBV = np.zeros(arr_shape)
 
     R_corr = R * 10 ** (0.4 * EBV * (k_4363 - k_5007))
 

--- a/Metallicity_Stack_Commons/column_names.py
+++ b/Metallicity_Stack_Commons/column_names.py
@@ -33,7 +33,7 @@ bin_names0 = ['bin_ID', 'N_stack', 'Detection']
 indv_names0 = ['ID', 'logR23', 'logO32', 'logM', 'logLHb', 'two_beta', 'three_beta', 'R']
 
 # Dust attenuation
-dust0 = ['HgHb', 'HdHb', 'EBV_HgHb', 'EBV_HdHb']
+dust0 = ['HgHb_composite', 'HdHb_composite', 'EBV_HgHb', 'EBV_HdHb']
 
 # Column names for bin information in stellar mass and H-beta luminosity
 bin_mzevolve_names0 = ['logM_min', 'logM_max', 'logM_avg', 'logM_median',

--- a/Metallicity_Stack_Commons/column_names.py
+++ b/Metallicity_Stack_Commons/column_names.py
@@ -74,11 +74,15 @@ filename_dict['bin_info'] = 'bin_info.tbl'
 filename_dict['bin_valid'] = 'bin_validation.tbl'
 filename_dict['bin_valid_rev'] = filename_dict['bin_valid'].replace('.tbl', '.revised.tbl')
 filename_dict['bin_fit'] = 'bin_emission_line_fit.tbl'
-filename_dict['bin_fit_rev'] = filename_dict['bin_fit'].replace('.tbl', '.MC.tbl')
+filename_dict['bin_fit_MC'] = filename_dict['bin_fit'].replace('.tbl', '.MC.tbl')
 filename_dict['bin_derived_prop'] = 'bin_derived_properties.tbl'
-filename_dict['bin_derived_prop_rev'] = filename_dict['bin_derived_prop'].replace('.tbl', '.MC.tbl')
+filename_dict['bin_derived_prop_v1'] = 'bin_derived_properties.valid1.tbl'
+filename_dict['bin_derived_prop_MC'] = filename_dict['bin_derived_prop'].replace('.tbl', '.MC.tbl')
+filename_dict['bin_derived_prop_MC_v1'] = filename_dict['bin_derived_prop_v1'].replace('.tbl', '.MC.tbl')
 filename_dict['bin_derived_prop_dust'] = filename_dict['bin_derived_prop'].replace('.tbl', '.dustcorr.tbl')
-filename_dict['bin_derived_prop_rev_dust'] = filename_dict['bin_derived_prop_rev'].replace('.tbl', '.dustcorr.tbl')
+filename_dict['bin_derived_prop_dust_v1'] = filename_dict['bin_derived_prop_v1'].replace('.tbl', '.dustcorr.tbl')
+filename_dict['bin_derived_prop_MC_dust'] = filename_dict['bin_derived_prop_MC'].replace('.tbl', '.dustcorr.tbl')
+filename_dict['bin_derived_prop_MC_dust_v1'] = filename_dict['bin_derived_prop_MC_v1'].replace('.tbl', '.dustcorr.tbl')
 
 # Individual galaxy/spectra-related files
 filename_dict['indv_prop'] = 'individual_properties.tbl'

--- a/Metallicity_Stack_Commons/column_names.py
+++ b/Metallicity_Stack_Commons/column_names.py
@@ -101,6 +101,15 @@ npz_filename_dict['der_prop_dust_pdf'] = npz_filename_dict['der_prop_pdf'].repla
 npz_filename_dict['der_prop_dust_errors'] = npz_filename_dict['der_prop_errors'].replace('.npz', '.dustcorr.npz')
 npz_filename_dict['der_prop_dust_peak'] = npz_filename_dict['der_prop_peak'].replace('.npz', '.dustcorr.npz')
 
+t_keys = list(npz_filename_dict.keys())
+for key in t_keys:
+    if 'dust' not in key:
+        npz_filename_dict[key+'_v1'] = npz_filename_dict[key].replace('.npz',
+                                                                      '.valid1.npz')
+    else:
+        npz_filename_dict[key+'_v1'] = npz_filename_dict[key].replace('.dustcorr.npz',
+                                                                      '.valid1.dustcorr.npz')
+
 
 def merge_column_names(*args):
     """

--- a/Metallicity_Stack_Commons/column_names.py
+++ b/Metallicity_Stack_Commons/column_names.py
@@ -93,6 +93,9 @@ npz_filename_dict['flux_peak'] = 'flux_peak.npz'
 npz_filename_dict['der_prop_pdf'] = 'derived_properties_pdf.npz'
 npz_filename_dict['der_prop_errors'] = 'derived_properties_errors.npz'
 npz_filename_dict['der_prop_peak'] = 'derived_properties_peak.npz'
+npz_filename_dict['der_prop_dust_pdf'] = npz_filename_dict['der_prop_pdf'].replace('.npz', '.dustcorr.npz')
+npz_filename_dict['der_prop_dust_errors'] = npz_filename_dict['der_prop_errors'].replace('.npz', '.dustcorr.npz')
+npz_filename_dict['der_prop_dust_peak'] = npz_filename_dict['der_prop_peak'].replace('.npz', '.dustcorr.npz')
 
 
 def merge_column_names(*args):


### PR DESCRIPTION
See iss #67

A couple of issues:
1. [x] There seems to be an issue with getting the same results with MC runs.  Some of the flux ratios differ. [79790f2]
2. [x] I noticed that the EBV_HdHb was much different between `raw=True` and `raw=False` [f986726]
3. [x] Need to change `filename_dict` convention to distinguish when `revised=False` or `True`

Addressing these issues below in other comments.

The following tests are needed to confirm the dust attenuation is working with `error_prop` and `ratios`:

## Zcalbase_gal

### No Randomization (`raw=True`)
1. - [x] Run `error_prop.fluxes_derived_prop` with `raw=True, binned_data=True, apply_dust=False, revised=False`
       - [x] Output file called bin_derived_properties.valid1.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite` (this is needed later since bin_derived_properties.tbl initial values are needed)
       - [x] Pass Chun's local test
       - [x] Pass Reagen's local test

2. - [x] Run `error_prop.fluxes_derived_prop` with `raw=True, binned_data=True, apply_dust=True, revised=False`
       - [x] Output file called bin_derived_properties.dustcorr.valid1.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains dust info: `HgHb`, `HdHb`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Pass Chun's local test
       - [x] Pass Reagen's local test

2. - [x] Run `error_prop.fluxes_derived_prop` with `raw=True, binned_data=True, apply_dust=True, revised=True`
       - [x] Output file called bin_derived_properties.tbl
       - [x] Pass Chun's local test

### Monte Carlo Randomization  (`raw=False`)

3. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=False, revised=False`
       - [x] Output file called bin_derived_properties.valid1.MC.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite`
       - [x] Include errors for `HgHb_composite`, `HdHb_composite`
       - [x] Pass Chun's local test
       - [x] Pass Reagen's local test

4. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=False, revised=True`
       - [x] Output file called bin_derived_properties.MC.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite`
       - [x] Include errors for `HgHb_composite`, `HdHb_composite`
       - [x] Pass Chun's local test
       - [x] Pass Reagen's local test

5. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=True, revised=True`
       - [x] Output file called 'bin_derived_properties.MC.dustcorr.tbl'
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains dust info: `HgHb_composite`, `HdHb_composite`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Contains errors for dust info: `HgHb_composite`, `HdHb_composite`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Pass Chun's local test
       - [x] Pass Reagen's local test

## Evolution_of_Galaxies

### No Randomization (`raw=True`)
1. - [x] Run `error_prop.fluxes_derived_prop` with `raw=True, binned_data=True, apply_dust=False, revised=False`
       - [x] Output file called bin_derived_properties.valid1.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite` (this is needed later since bin_derived_properties.tbl initial values are needed)
       - [x] Pass Chun's local test
       - [x] Pass Caroline's local test
          - [x] Mass bins
          - [x] Mass-LHbeta bins

2. - [x] Run `error_prop.fluxes_derived_prop` with `raw=True, binned_data=True, apply_dust=True, revised=False`
       - [x] Output file called bin_derived_properties.dustcorr.valid1.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains dust info: `HgHb_composite`, `HdHb_composite`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Pass Chun's local test
       - [x] Pass Caroline's local test
          - [x] Mass bins
          - [x] Mass-LHbeta bins

### Monte Carlo Randomization (`raw=False`)

3. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=False, revised=False`
       - [x] Output file called bin_derived_properties.valid1.MC.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite`
       - [x] Include errors for `HgHb_composite`, `HdHb_composite`
       - [x] Pass Chun's local test
       - [x] Pass Caroline's local test
          - [x] Mass bins
          - [x] Mass-LHbeta bins

4. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=False, revised=True`
       - [x] Output file called bin_derived_properties.MC.tbl
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Include `HgHb_composite`, `HdHb_composite`
       - [x] Pass Chun's local test
       - [x] Pass Caroline's local test
          - [x] Mass bins
          - [x] Mass-LHbeta bins

5. - [x] Run `error_prop.fluxes_derived_prop` with `raw=False, binned_data=True, apply_dust=True, revised=True`
       - [x] Output file called 'bin_derived_properties.MC.dustcorr.tbl'
       - [x] Contains flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains errors for flux ratios: `two_beta_composite`, `three_beta_composite`, `R_composite`
       - [x] Contains errors for flux ratios: `logR23_composite`, `logO32_composite`
       - [x] Contains derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains errors for derived properties: `T_e`, `12+log(O/H)`, `log(O+/H)`, `log(O++/H)`, `O+/H`, `O++/H`
       - [x] Contains dust info: `HgHb_composite`, `HdHb_composite`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Contains errors for dust info: `HgHb_composite`, `HdHb_composite`, `EBV_HgHb`, and `EBV_HdHb`
       - [x] Pass Chun's local test
       - [x] Pass Caroline's local test
          - [x] Mass bins
          - [x] Mass-LHbeta bins