### PR TITLE
Use platform.uname instead of os.uname - Windows compatibility

### DIFF
--- a/Metallicity_Stack_Commons/__init__.py
+++ b/Metallicity_Stack_Commons/__init__.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from .logging import log_stdout, log_verbose
 
-version = "1.4.2"
+version = "1.4.3"
 
 lambda0   = [3726.18, 4101.73, 4340.46, 4363.21, 4861.32, 4958.91, 5006.84]
 line_type = ['Oxy2', 'Balmer', 'Balmer', 'Single', 'Balmer', 'Single', 'Single']

--- a/Metallicity_Stack_Commons/logging.py
+++ b/Metallicity_Stack_Commons/logging.py
@@ -1,6 +1,6 @@
 import sys
 from os.path import join
-from os import uname
+from platform import uname
 
 from getpass import getuser
 from socket import gethostname

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='Metallicity_Stack_Commons',
-    version='1.4.2',
+    version='1.4.3',
     packages=['Metallicity_Stack_Commons'],
     url='https://github.com/astrochun/Metallicity_Stack_Commons',
     license='MIT License',


### PR DESCRIPTION
Fixes #107 